### PR TITLE
fix: fix incorrect import of `gethclient` library

### DIFF
--- a/withdraw/withdraw.go
+++ b/withdraw/withdraw.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
-	"github.com/ethereum/go-ethereum/ethclient/gethclient"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 


### PR DESCRIPTION
The import of the non-existent `gethclient` library from the official `go-ethereum` package was causing a compile-time error. I’ve removed the import to fix the issue.