### PR TITLE
Use earliest suitable game for proving withdrawals

### DIFF
--- a/withdraw/fpwithdraw.go
+++ b/withdraw/fpwithdraw.go
@@ -2,6 +2,7 @@ package withdraw
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"time"
@@ -84,7 +85,7 @@ func (w *FPWithdrawer) ProveWithdrawal() error {
 	l2 := ethclient.NewClient(w.L2Client)
 	l2g := gethclient.New(w.L2Client)
 
-	params, err := withdrawals.ProveWithdrawalParametersFaultProofs(w.Ctx, l2g, l2, l2, w.L2TxHash, &w.Factory.DisputeGameFactoryCaller, &w.Portal.OptimismPortal2Caller)
+	params, err := ProveWithdrawalParametersFaultProofs(w.Ctx, l2g, l2, l2, w.L2TxHash, &w.Factory.DisputeGameFactoryCaller, &w.Portal.OptimismPortal2Caller)
 	if err != nil {
 		return err
 	}
@@ -140,10 +141,14 @@ func (w *FPWithdrawer) FinalizeWithdrawal() error {
 
 	// get the WithdrawalTransaction info needed to finalize the withdrawal
 	l2 := ethclient.NewClient(w.L2Client)
-	l2g := gethclient.New(w.L2Client)
 
-	// we only use info from this call that isn't block-specific, so it's safe to call this again
-	params, err := withdrawals.ProveWithdrawalParametersFaultProofs(w.Ctx, l2g, l2, l2, w.L2TxHash, &w.Factory.DisputeGameFactoryCaller, &w.Portal.OptimismPortal2Caller)
+	// Transaction receipt
+	receipt, err := l2.TransactionReceipt(w.Ctx, w.L2TxHash)
+	if err != nil {
+		return err
+	}
+	// Parse the receipt
+	ev, err := withdrawals.ParseMessagePassed(receipt)
 	if err != nil {
 		return err
 	}
@@ -152,12 +157,12 @@ func (w *FPWithdrawer) FinalizeWithdrawal() error {
 	tx, err := w.Portal.FinalizeWithdrawalTransaction(
 		w.Opts,
 		bindingspreview.TypesWithdrawalTransaction{
-			Nonce:    params.Nonce,
-			Sender:   params.Sender,
-			Target:   params.Target,
-			Value:    params.Value,
-			GasLimit: params.GasLimit,
-			Data:     params.Data,
+			Nonce:    ev.Nonce,
+			Sender:   ev.Sender,
+			Target:   ev.Target,
+			Value:    ev.Value,
+			GasLimit: ev.GasLimit,
+			Data:     ev.Data,
 		},
 	)
 	if err != nil {
@@ -170,4 +175,64 @@ func (w *FPWithdrawer) FinalizeWithdrawal() error {
 	ctxWithTimeout, cancel := context.WithTimeout(w.Ctx, 5*time.Minute)
 	defer cancel()
 	return waitForConfirmation(ctxWithTimeout, w.L1Client, tx.Hash())
+}
+
+// ProveWithdrawalParametersFaultProofs calls ProveWithdrawalParametersForBlock with the most recent L2 output after the latest game.
+func ProveWithdrawalParametersFaultProofs(ctx context.Context, proofCl withdrawals.ProofClient, l2ReceiptCl withdrawals.ReceiptClient, l2BlockCl withdrawals.BlockClient, txHash common.Hash, disputeGameFactoryContract *bindings.DisputeGameFactoryCaller, optimismPortal2Contract *bindingspreview.OptimismPortal2Caller) (withdrawals.ProvenWithdrawalParameters, error) {
+	latestGame, err := FindEarliestGame(ctx, l2ReceiptCl, txHash, disputeGameFactoryContract, optimismPortal2Contract)
+	if err != nil {
+		return withdrawals.ProvenWithdrawalParameters{}, fmt.Errorf("failed to find latest game: %w", err)
+	}
+
+	l2BlockNumber := new(big.Int).SetBytes(latestGame.ExtraData[0:32])
+	l2OutputIndex := latestGame.Index
+	return withdrawals.ProveWithdrawalParametersForBlock(ctx, proofCl, l2ReceiptCl, l2BlockCl, txHash, l2BlockNumber, l2OutputIndex)
+}
+
+// FindEarliestGame finds the earliest game in the DisputeGameFactory contract that is after the given transaction receipt.
+func FindEarliestGame(ctx context.Context, l2ReceiptCl withdrawals.ReceiptClient, txHash common.Hash, disputeGameFactoryContract *bindings.DisputeGameFactoryCaller, optimismPortal2Contract *bindingspreview.OptimismPortal2Caller) (*bindings.IDisputeGameFactoryGameSearchResult, error) {
+	receipt, err := l2ReceiptCl.TransactionReceipt(ctx, txHash)
+	if err != nil {
+		return nil, err
+	}
+
+	respectedGameType, err := optimismPortal2Contract.RespectedGameType(&bind.CallOpts{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get respected game type: %w", err)
+	}
+
+	gameCount, err := disputeGameFactoryContract.GameCount(&bind.CallOpts{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get game count: %w", err)
+	}
+	if gameCount.Cmp(common.Big0) == 0 {
+		return nil, errors.New("no games")
+	}
+
+	lo := new(big.Int)
+	hi := new(big.Int).Sub(gameCount, common.Big1)
+
+	for lo.Cmp(hi) < 0 {
+		mid := new(big.Int).Add(lo, hi)
+		mid.Div(mid, common.Big2)
+		latestGames, err := disputeGameFactoryContract.FindLatestGames(&bind.CallOpts{}, respectedGameType, mid, common.Big1)
+		if err != nil {
+			return nil, err
+		}
+		latestGame := latestGames[0]
+		l2BlockNumber := new(big.Int).SetBytes(latestGame.ExtraData[0:32])
+		if l2BlockNumber.Cmp(receipt.BlockNumber) < 0 {
+			lo = mid.Add(mid, common.Big1)
+		} else {
+			hi = mid
+		}
+	}
+
+	latestGames, err := disputeGameFactoryContract.FindLatestGames(&bind.CallOpts{}, respectedGameType, lo, common.Big1)
+	if err != nil {
+		return nil, err
+	}
+	latestGame := latestGames[0]
+
+	return &latestGame, nil
 }


### PR DESCRIPTION
This allows folks to finalize withdrawals sooner, because they prove using a game that will resolve earlier.